### PR TITLE
Fix Empty Filter Query

### DIFF
--- a/src/main/java/servlets/PlacesListServlet.java
+++ b/src/main/java/servlets/PlacesListServlet.java
@@ -39,9 +39,10 @@ public class PlacesListServlet extends HttpServlet {
             .location(currentLocation)
             .radius(500) // Metres, can change via filter
             .openNow(true)
-            .type(PlaceType.RESTAURANT)
-            .keyword(filter);
+            .type(PlaceType.RESTAURANT);
         
+        if (!filter.isEmpty()) nearbySearch.keyword(filter);
+
         try {
             PlacesSearchResponse nearby = nearbySearch.await(); //Returns top 20 results(One page)
 

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -80,11 +80,11 @@ function initMap() {
     }
 
     const url = new URL('/places-list', window.location.origin),
-        params = {
-          lat: place.geometry.location.lat(),
-          lng: place.geometry.location.lng(),
-          filter: getDieteryRestrictions()
-        }
+          params = {
+            lat: place.geometry.location.lat(),
+            lng: place.geometry.location.lng(),
+            filter: getDieteryRestrictions()
+          }
     Object.keys(params).forEach(key => url.searchParams.append(key, params[key]))
 
     fetch(url).then((response => {
@@ -181,7 +181,7 @@ function getDieteryRestrictions() {
        return filter.value;
      }
    }
-   return null;
+   return '';
 }
 
 const filterButtons = document.getElementsByName("restaurant-filter");


### PR DESCRIPTION
This commit fixes a bug whereby an empty filter query is searching
for the keyword null, thus returning no/few restaurants.

Fixed demo: https://jtan-sps-summer20.appspot.com/
Wrong demo: https://summer20-sps-48.appspot.com/

Steps to reproduce: 
1. 'Tiong Bahru Plaza' with no filter.
2. Wrong demo will show no restaurants, Fixed will show multiple restaurants
