### PR TITLE
Add About Tab

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -42,12 +42,60 @@
         <div id="info-restaurant-name"></div>
       </div>
     </div>
+    <div id="about-container" class="collapse-about-container">
+      <div class="linkedin-container">
+        <span class="linkedin-text-container">
+          <span class="linkedin-text">
+            J.L.
+          </span>
+        </span>
+        <a class="linkedin-button" href="https://www.linkedin.com/in/jieliangang">
+          <img class="linkedin-button-img" src="https://media-exp1.licdn.com/dms/image/C5103AQG7rN1td9pcaQ/profile-displayphoto-shrink_200_200/0?e=1602115200&v=beta&t=MHavbs22FYFy0rH1t0k_1KaZz04hfE4uSvvefZ1x_sw">
+        </a>
+      </div>
+      <div class="linkedin-container">
+        <span class="linkedin-text-container">
+          <span class="linkedin-text">
+            D.L.
+          </span>
+        </span>
+        <a class="linkedin-button" href="https://www.linkedin.com/in/daekoon">
+          <img class="linkedin-button-img" src="https://media-exp1.licdn.com/dms/image/C5103AQFo3lPMuxPBOA/profile-displayphoto-shrink_200_200/0?e=1602115200&v=beta&t=aqNEvE_6rJ4p-R4aAZgEDbQ_qccF2bHUULyuEAYZw5o">
+        </a>
+      </div>
+      <div class="linkedin-container">
+        <span class="linkedin-text-container">
+          <span class="linkedin-text">
+            L.Y.
+          </span>
+        </span>
+        <a class="linkedin-button" href="https://www.linkedin.com/in/leon-yeo-0368a2166">
+          <img class="linkedin-button-img" src="https://media-exp1.licdn.com/dms/image/C5603AQFY62RhDwozGg/profile-displayphoto-shrink_200_200/0?e=1602115200&v=beta&t=1VIsojoLR9hH1OUjj3GZC4KW6KntHqc_5KizPW2_7GI">
+        </a>
+      </div>
+      <div class="linkedin-container">
+        <span class="linkedin-text-container">
+          <span class="linkedin-text">
+            J.T.
+          </span>
+        </span>
+        <a class="linkedin-button" href="https://www.linkedin.com/in/lolfuljames">
+          <img class="linkedin-button-img" src="https://media-exp1.licdn.com/dms/image/C5103AQFEyYg3uhsK6g/profile-displayphoto-shrink_200_200/0?e=1602115200&v=beta&t=pmaJhoBd6lU6n3XqkFnOSJS_na5A10ysxxiBceVY9-Q">
+        </a>
+      </div>
+      <button id="collapse-about-button" class="hide about-button">
+        <span class="iconify" data-icon="bi:arrow-bar-left" data-inline="false" data-height="25px"></span>
+      </button>
+      <button id="expand-about-button" class="show about-button">
+        <span class="iconify" data-icon="ant-design:team-outlined" data-inline="false" data-height="25px"></span>
+      </button>
+      </div>
     <div id="right-tab">
       <div id="pac-card">
         <h1>EatGoWhere</h1>
         <button id="resize-nav-button">
-          <span id="expand-top-button" class="iconify show" data-icon="bi:filter" data-inline="false" data-width="25px" data-height="25px" style="color: gray;"></span>
-          <span id="collapse-top-button"class="iconify hide" data-icon="bi:arrows-collapse" data-inline="false" data-width="25px" data-height="25px" style="color: gray;"></span>
+          <span id="expand-top-button" class="iconify hide" data-icon="bi:filter" data-inline="false" data-width="25px" data-height="25px" style="color: gray;"></span>
+          <span id="collapse-top-button"class="iconify show" data-icon="bi:arrows-collapse" data-inline="false" data-width="25px" data-height="25px" style="color: gray;"></span>
         </button>
         <input id="pac-input" type="text" placeholder="Enter your location" />
         <span id="pac-clear" onClick='clearPACInput()'>&times;</span>
@@ -109,7 +157,6 @@
           </form>
         </div>
       </div>
-
       <div id="result-container">
         <div id="result-scroll-container">
           <button id="result-hide-button">
@@ -165,6 +212,7 @@
           </div>
 
         </div>
+
 
       </div>
     </div>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -43,6 +43,9 @@
       </div>
     </div>
     <div id="about-container" class="collapse-about-container">
+      <div id="about-title">
+        The Devs
+      </div>
       <div class="linkedin-container">
         <span class="linkedin-text-container">
           <span class="linkedin-text">
@@ -212,7 +215,6 @@
           </div>
 
         </div>
-
 
       </div>
     </div>

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -421,3 +421,40 @@ document.getElementById("distance-filter").addEventListener("input",function() {
   let distance = this.value;
   document.getElementById("distance-filter-max").innerText = distance + "m"
 });
+
+function resizeAboutButton(collapse=false) {
+  const expandButton = document.getElementById("expand-about-button");
+  const collapseButton = document.getElementById("collapse-about-button");
+  let aboutBar = document.getElementById("about-container");
+  let filterContainer = document.getElementById("pac-container");
+  if (collapse) {
+    expandButton.classList.replace("hide", "show");
+    collapseButton.classList.replace("show", "hide");
+    aboutBar.classList.remove("expand-about-container");
+  }
+  else {
+    expandButton.classList.replace("show", "hide");
+    collapseButton.classList.replace("hide", "show");
+    aboutBar.classList.add("expand-about-container");
+  }
+}
+
+function isTouch() {
+  return 'ontouchstart' in window || navigator.msMaxTouchPoints;
+}
+
+document.getElementById("about-container").addEventListener("mouseover", function(){
+  if (!isTouch()) resizeAboutButton(collapse=false); //prevent duplicate events on touchscreen
+});
+
+document.getElementById("about-container").addEventListener("mouseout", function(){
+  if (!isTouch()) resizeAboutButton(collapse=true); //prevent duplicate events on touchscreen
+});
+
+document.getElementById("expand-about-button").addEventListener("click", function(){
+  resizeAboutButton(collapse=false);
+});
+
+document.getElementById("collapse-about-button").addEventListener("click", function(){
+  resizeAboutButton(collapse=true);
+});

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -382,7 +382,7 @@ h1 {
 }
 
 .collapse-about-container {
-  left: -270px;
+  left: -320px;
 }
 
 .expand-about-container {
@@ -436,6 +436,10 @@ h1 {
   box-shadow: 0px 0px 0px transparent;
   border: 0px solid transparent;
   text-shadow: 0px 0px 0px transparent;
+}
+
+#about-title {
+  width: 50px;
 }
 
 @media only screen and (max-width: 768px) {

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -382,11 +382,11 @@ h1 {
 }
 
 .collapse-about-container {
-  left: -320px;
+  left: -360px;
 }
 
 .expand-about-container {
-  left: -30px;
+  left: -75px;
 }
 
 .linkedin-container:hover .linkedin-button-img{
@@ -440,6 +440,10 @@ h1 {
 
 #about-title {
   width: 50px;
+  position: relative;
+  background-color: white;
+  border-radius: 300px;
+  padding: 10px 0px 10px 40px;
 }
 
 @media only screen and (max-width: 768px) {
@@ -516,6 +520,10 @@ h1 {
     margin-bottom: 6px;
     padding: 11px 12px 11px 12px; /*looks rounder this way for some reason*/
     background-color: white;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+  }
+
+  #about-title {
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
   }
 }

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -369,6 +369,75 @@ h1 {
   appearance: none;
 }
 
+#about-container {
+  position: absolute;
+  bottom: 60px;
+  transition: 0.3s ease-in;
+  display: flex;
+  align-items: center;
+  background-color: #FEFEFE;
+  border-radius: 30px;
+  padding: 10px 20px 10px 50px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+}
+
+.collapse-about-container {
+  left: -270px;
+}
+
+.expand-about-container {
+  left: -30px;
+}
+
+.linkedin-container:hover .linkedin-button-img{
+  opacity: 25%;
+}
+
+.linkedin-container:hover .linkedin-text{
+  opacity: 100%;
+}
+
+.linkedin-container {
+  display: flex;
+  align-items: center;
+}
+
+.linkedin-text {
+  opacity: 0;
+  transition: 0.5s ease-in;
+  position: absolute;
+  left: 13px;
+  bottom: -13px;
+  font-size: 1.5em;
+}
+
+.linkedin-text-container {
+  position: relative;
+}
+
+.linkedin-button-img {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+  border-radius: 300px;
+  height: 50px;
+  margin-left: 5px;
+  transition: 0.3s ease-out;
+}
+
+.about-button {
+  background: transparent;
+  box-shadow: 0px 0px 0px transparent;
+  border: 0px solid transparent;
+  text-shadow: 0px 0px 0px transparent;
+  margin-left: 10px;
+}
+
+#resize-about-button:hover {
+  background: transparent;
+  box-shadow: 0px 0px 0px transparent;
+  border: 0px solid transparent;
+  text-shadow: 0px 0px 0px transparent;
+}
+
 @media only screen and (max-width: 768px) {
   #map-container {
     height: 100%;
@@ -429,5 +498,20 @@ h1 {
     width: 250px;
     object-fit: cover;
     margin: .5rem 0;
+  }
+
+  #about-container {
+    background-color: transparent;
+    box-shadow: none;
+    pointer-events: all;
+  }
+
+  .about-button {
+    border-radius: 900px;
+    margin-left: 15px;
+    margin-bottom: 6px;
+    padding: 11px 12px 11px 12px; /*looks rounder this way for some reason*/
+    background-color: white;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
   }
 }


### PR DESCRIPTION
About tab that includes our pictures. Clicking on it redirects to our linkedin!

On PC, hover activates the about tab:
Collapsed:
![image](https://user-images.githubusercontent.com/30533810/89706645-3f650f00-d99a-11ea-928c-daebe7085660.png)

Expanded:
![image](https://user-images.githubusercontent.com/30533810/89707681-109f6680-d9a3-11ea-973c-acebd8866ac9.png)


On Mobile, clicking the button activates the about tab, tab background is only available on the button so that it doesn't show up when result-container is open.

Collapsed:
![image](https://user-images.githubusercontent.com/30533810/89706666-79361580-d99a-11ea-81ea-ab8a6da2c560.png)

Expanded:
![image](https://user-images.githubusercontent.com/30533810/89707693-2ad94480-d9a3-11ea-8e3b-ba1d22d2cb83.png)


Demo: https://jtan-sps-summer20.appspot.com/
Note when testing: If you use dev tools to check out the mobile site, you will have to refresh the page for the collapse function to work properly (because it was loaded from a pc-perspective initially), if you use your phone you can just ignore it.
