### PR TITLE
Tweaks to Collapsing of Menus

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -110,7 +110,7 @@
         </div>
       </div>
 
-      <div id="result-container">
+      <div id="result-container" class="hide">
         <div id="result-scroll-container">
           <button id="result-hide-button">
             <span class="iconify" data-icon="dashicons:arrow-down-alt2" data-inline="false"></span>

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -93,7 +93,8 @@ function initMap() {
     }
 
     resizeNavButton(keepCollapsed=true);
-    document.getElementById("result-container").classList.add("hide");
+    setRestaurantTab(hidden=true);
+    resultHidden=true;
 
     const url = new URL('/places-list', window.location.origin),
           params = {
@@ -124,7 +125,6 @@ let restaurants;
 let restaurantIndex = 0;
 function updateRestaurant(result) {
   let resContainerElement = document.getElementById("result-container");
-  resContainerElement.style.display = "block";
 
   shuffleArray(result);
   restaurants = result;
@@ -136,17 +136,7 @@ function updateRestaurant(result) {
     document.getElementById("restaurant-details").style.display = "flex";
     document.getElementById("no-result-text").style.display = "none";
 
-    resContainerElement.classList.remove("hide");
-    resContainerElement.scrollTop = 0;
-    document.getElementById("infowindow-restaurant-content").classList.remove("hide");
-
     updateRestaurantDetails(0);
-
-    // Show restaurant tab if hidden
-    if(resultHidden) {
-      resultHidden = false;
-      setRestaurantTab(resultHidden);
-    }
 
     // Hide next and previous buttons if only one restaurant
     if(result.length === 1) {
@@ -154,6 +144,16 @@ function updateRestaurant(result) {
     } else {
       document.getElementById("restaurant-buttons").style.display = "flex";
     }
+    resContainerElement.classList.remove("hide");
+    resContainerElement.scrollTop = 0;
+    document.getElementById("infowindow-restaurant-content").classList.remove("hide");
+  }
+  resContainerElement.classList.remove("hide");
+  
+  // Show restaurant tab if hidden
+  if(resultHidden) {
+    resultHidden = false;
+    setRestaurantTab(resultHidden);
   }
 }
 
@@ -254,7 +254,7 @@ document.getElementById("next-button").addEventListener("click", function() {
   nextRestaurant();
 });
 
-let resultHidden = false;
+let resultHidden = true;
 document.getElementById("result-hide-button").addEventListener("click", function() {
   resultHidden = !resultHidden;
   setRestaurantTab(resultHidden);
@@ -369,6 +369,7 @@ function resizeNavButton(keepCollapsed=false) {
     expandButton.classList.replace("show", "hide");
     collapseButton.classList.replace("hide", "show");
     setRestaurantTab(hidden=true);
+    resultHidden = true;
   }
 }
 

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -258,6 +258,7 @@ let resultHidden = false;
 document.getElementById("result-hide-button").addEventListener("click", function() {
   resultHidden = !resultHidden;
   setRestaurantTab(resultHidden);
+  if (!resultHidden) resizeNavButton(keepCollapsed=true);
 });
 
 function updateRating(rating) {
@@ -367,6 +368,7 @@ function resizeNavButton(keepCollapsed=false) {
     filterContainer.style.overflowY = "auto";
     expandButton.classList.replace("show", "hide");
     collapseButton.classList.replace("hide", "show");
+    setRestaurantTab(hidden=true);
   }
 }
 
@@ -398,6 +400,8 @@ function updateLocation(result) {
   map.panTo(coords);
   map.setZoom(17);
   
+  // auto search if user gps is enabled
+  document.getElementById("submit-button").click();
   gtag('event', 'gps');
 }
 

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -140,6 +140,10 @@ h1 {
   align-items: center;
 }
 
+#no-result-text {
+  text-align: center;
+}
+
 #restaurant-details {
   display: flex;
   flex-direction: column;

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -126,7 +126,6 @@ h1 {
 }
 
 #result-container {
-  display: none;
   margin: 10px;
   padding: 20px;
   border-radius: 8px;


### PR DESCRIPTION
Add Quality of Life Improvement for Mobile

-Autosearch when user gps is available
-Bottom menu closes when top is expanded, vice-versa
-Fixes the bug whereby no restaurant found wasn't being shown.
-Replaces hiding result container with collapsing of result container
 upon pressing search.
-Change order of showing information (delaying it to final parts so information is only shown when ready, photos of restaurants are an exception to this)

demo: https://jtan-sps-summer20.appspot.com/